### PR TITLE
Add support for Solong wallet extension

### DIFF
--- a/src/utils/solong_adapter.tsx
+++ b/src/utils/solong_adapter.tsx
@@ -2,7 +2,7 @@ import EventEmitter from 'eventemitter3';
 import { PublicKey } from '@solana/web3.js';
 import { notify } from "./notifications";
 
-export class SolongBridge extends EventEmitter {
+export class SolongAdapter extends EventEmitter {
   _publicKey: any
   _onProcess:boolean
   constructor(providerUrl: string, network: string) {

--- a/src/utils/solong_bridge.tsx
+++ b/src/utils/solong_bridge.tsx
@@ -32,7 +32,16 @@ export class SolongBridge extends EventEmitter {
         console.log('window solong select:', account, 'this:', this);
         this.emit('connect', this._publicKey);
       })
-      .catch(() => {})
+      .catch(() => {
+        this.disconnect()
+      })
       .finally(()=>{this._onProcess=false});
+  }
+
+  disconnect (){
+    if (this._publicKey) {
+      this._publicKey = null;
+      this.emit('disconnect');
+    }
   }
 }

--- a/src/utils/solong_bridge.tsx
+++ b/src/utils/solong_bridge.tsx
@@ -1,0 +1,38 @@
+import EventEmitter from 'eventemitter3';
+import { PublicKey } from '@solana/web3.js';
+
+export class SolongBridge extends EventEmitter {
+  _publicKey: any
+  _onProcess:boolean
+  constructor(providerUrl: string, network: string) {
+    super()
+    this._publicKey = null;
+    this._onProcess = false;
+    this.connect= this.connect.bind(this);
+  }
+
+  get publicKey() {
+    return this._publicKey;
+  }
+
+  async signTransaction(transaction: any) {
+    return (window as any).solong.signTransaction(transaction);
+  }
+
+  connect() {
+    if (this._onProcess) {
+      return ;
+    }
+    this._onProcess = true;
+    console.log('solong helper select account');
+    (window as any).solong
+      .selectAccount()
+      .then((account: any) => {
+        this._publicKey = new PublicKey(account);
+        console.log('window solong select:', account, 'this:', this);
+        this.emit('connect', this._publicKey);
+      })
+      .catch(() => {})
+      .finally(()=>{this._onProcess=false});
+  }
+}

--- a/src/utils/solong_bridge.tsx
+++ b/src/utils/solong_bridge.tsx
@@ -1,5 +1,6 @@
 import EventEmitter from 'eventemitter3';
 import { PublicKey } from '@solana/web3.js';
+import { notify } from "./notifications";
 
 export class SolongBridge extends EventEmitter {
   _publicKey: any
@@ -23,6 +24,15 @@ export class SolongBridge extends EventEmitter {
     if (this._onProcess) {
       return ;
     }
+
+    if ((window as any).solong === undefined){
+      notify({
+        message: "Solong Error",
+        description: "Please install solong wallet from Chrome " ,
+      });
+      return;
+    }
+
     this._onProcess = true;
     console.log('solong helper select account');
     (window as any).solong

--- a/src/utils/wallet.tsx
+++ b/src/utils/wallet.tsx
@@ -3,7 +3,7 @@ import Wallet from "@project-serum/sol-wallet-adapter";
 import { notify } from "./notifications";
 import { useConnectionConfig } from "./connection";
 import { useLocalStorageState } from "./utils";
-import {SolongBridge} from "./solong_bridge";
+import {SolongAdapter} from "./solong_adapter";
 
 export const WALLET_PROVIDERS = [
   { name: "sollet.io", url: "https://www.sollet.io" },
@@ -22,7 +22,7 @@ export function WalletProvider({ children = null as any }) {
   const wallet = useMemo(() => {
     console.log("use new provider:", providerUrl, " endpoint:", endpoint)
     if (providerUrl==="http://solongwallet.com")  {
-      return new SolongBridge(providerUrl, endpoint);
+      return new SolongAdapter(providerUrl, endpoint);
     } else {
       return new Wallet(providerUrl, endpoint)
     }}, [

--- a/src/utils/wallet.tsx
+++ b/src/utils/wallet.tsx
@@ -3,10 +3,12 @@ import Wallet from "@project-serum/sol-wallet-adapter";
 import { notify } from "./notifications";
 import { useConnectionConfig } from "./connection";
 import { useLocalStorageState } from "./utils";
+import {SolongBridge} from "./solong_bridge";
 
 export const WALLET_PROVIDERS = [
   { name: "sollet.io", url: "https://www.sollet.io" },
   { name: "solflare.com", url: "https://solflare.com/access-wallet" },
+  { name: "solongwallet.com", url: "http://solongwallet.com" },
 ];
 
 const WalletContext = React.createContext<any>(null);
@@ -17,7 +19,13 @@ export function WalletProvider({ children = null as any }) {
     "walletProvider",
     "https://www.sollet.io"
   );
-  const wallet = useMemo(() => new Wallet(providerUrl, endpoint), [
+  const wallet = useMemo(() => {
+    console.log("use new provider:", providerUrl, " endpoint:", endpoint)
+    if (providerUrl==="http://solongwallet.com")  {
+      return new SolongBridge(providerUrl, endpoint);
+    } else {
+      return new Wallet(providerUrl, endpoint)
+    }}, [
     providerUrl,
     endpoint,
   ]);

--- a/src/utils/wallet.tsx
+++ b/src/utils/wallet.tsx
@@ -7,8 +7,8 @@ import {SolongAdapter} from "./solong_adapter";
 
 export const WALLET_PROVIDERS = [
   { name: "sollet.io", url: "https://www.sollet.io" },
-  { name: "solflare.com", url: "https://solflare.com/access-wallet" },
   { name: "solongwallet.com", url: "http://solongwallet.com" },
+  { name: "solflare.com", url: "https://solflare.com/access-wallet" },
 ];
 
 const WalletContext = React.createContext<any>(null);


### PR DESCRIPTION
The [SolongWallet Chrome Extension](http://solongwallet.com/) has already publish on [Chome extension store](https://chrome.google.com/webstore/category/extensions).

And we add SolongAdapter which works like [sol-wallet-adapter](https://github.com/project-serum/sol-wallet-adapter)
to support Dapps which already use [sol-wallet-adapter](https://github.com/project-serum/sol-wallet-adapter)